### PR TITLE
Apply the Beman Standard: license related rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,7 @@
+# CMakeLists.txt -*-CMake-*-
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 cmake_minimum_required(VERSION 3.10)
 
 project(beman_iter_interface VERSION 0.0.0 LANGUAGES CXX)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 #! /usr/bin/make -f
-# -*-makefile-*-
+# cmake-format: off
+# /Makefile -*-makefile-*-
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# cmake-format: on
 
 INSTALL_PREFIX?=.install/
 PROJECT?=$(shell basename $(CURDIR))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 #! /usr/bin/make -f
-# cmake-format: off
 # /Makefile -*-makefile-*-
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # cmake-format: on

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 #! /usr/bin/make -f
 # /Makefile -*-makefile-*-
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-# cmake-format: on
 
 INSTALL_PREFIX?=.install/
 PROJECT?=$(shell basename $(CURDIR))

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # beman.iterator\_interface: iterator creation mechanisms
 
+<!--
+SPDX-License-Identifier: 2.0 license with LLVM exceptions
+-->
 
 **Implements**:
 * [`std::iterator_interface` (P2727)](https://wg21.link/P2727)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,7 @@
+# examples/CMakeLists.txt -*-CMake-*-
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 include(GNUInstallDirs)
 
 # List of all buildable examples.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,9 @@
 # Beman.iterator Examples
 
+<!--
+SPDX-License-Identifier: 2.0 license with LLVM exceptions
+-->
+
 List of usage examples for `Beman.iterator`.
 
 ## Sample

--- a/examples/sample.cpp
+++ b/examples/sample.cpp
@@ -1,3 +1,6 @@
+// examples/sample.cpp -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <beman/iterator_interface/iterator_interface.hpp>
 #include <iostream>
 

--- a/include/beman/iterator_interface/config.hpp.in
+++ b/include/beman/iterator_interface/config.hpp.in
@@ -1,3 +1,6 @@
+// include/beman/iterator_interface/config.hpp.in -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #ifndef BEMAN_ITERATOR_INTERFACE_CONFIG_HPP
 #define BEMAN_ITERATOR_INTERFACE_CONFIG_HPP
 

--- a/include/beman/iterator_interface/detail/stl_interfaces/config.hpp
+++ b/include/beman/iterator_interface/detail/stl_interfaces/config.hpp
@@ -1,3 +1,4 @@
+// include/beman/iterator_interface/detail/stl_interfaces/config.hpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // Copyright (C) 2020 T. Zachary Laine

--- a/include/beman/iterator_interface/detail/stl_interfaces/fwd.hpp
+++ b/include/beman/iterator_interface/detail/stl_interfaces/fwd.hpp
@@ -1,3 +1,4 @@
+// include/beman/iterator_interface/detail/stl_interfaces/fwd.hpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // Copyright (C) 2019 T. Zachary Laine

--- a/include/beman/iterator_interface/detail/stl_interfaces/iterator_interface.hpp
+++ b/include/beman/iterator_interface/detail/stl_interfaces/iterator_interface.hpp
@@ -1,3 +1,4 @@
+// include/beman/iterator_interface/detail/stl_interfaces/iterator_interface.hpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // Copyright (C) 2019 T. Zachary Laine

--- a/include/beman/iterator_interface/iterator_interface.hpp
+++ b/include/beman/iterator_interface/iterator_interface.hpp
@@ -1,4 +1,6 @@
-// iterator_interface.hpp                                             -*-C++-*-
+// include/beman/iterator_interface/iterator_interface.hpp -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #ifndef INCLUDED_ITERATOR_INTERFACE
 #define INCLUDED_ITERATOR_INTERFACE
 

--- a/include/beman/iterator_interface/iterator_interface_access.hpp
+++ b/include/beman/iterator_interface/iterator_interface_access.hpp
@@ -1,3 +1,6 @@
+// include/beman/iterator_interface/iterator_interface_access.hpp -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #ifndef ITERATOR_INTERFACE_ACCESSS_HPP
 #define ITERATOR_INTERFACE_ACCESSS_HPP
 

--- a/src/beman/iterator_interface/CMakeLists.txt
+++ b/src/beman/iterator_interface/CMakeLists.txt
@@ -1,3 +1,7 @@
+# src/beman/iterator_interface/CMakeLists.txt -*-CMake-*-
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 add_library(beman.iterator_interface)
 add_library(beman::iterator_interface ALIAS beman.iterator_interface)
 

--- a/src/beman/iterator_interface/iterator_interface.cpp
+++ b/src/beman/iterator_interface/iterator_interface.cpp
@@ -1,1 +1,4 @@
+// src/beman/iterator_interface/iterator_interface.cpp -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <beman/iterator_interface/iterator_interface.hpp>

--- a/src/beman/iterator_interface/iterator_interface.t.cpp
+++ b/src/beman/iterator_interface/iterator_interface.t.cpp
@@ -1,4 +1,6 @@
-// iterator_interface.t.cpp                                           -*-C++-*-
+// src/beman/iterator_interface/iterator_interface.y.cpp -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <beman/iterator_interface/iterator_interface.hpp>
 #include <beman/iterator_interface/iterator_interface.hpp>
 


### PR DESCRIPTION
Apply the Beman Standard: license related rules - #1 

This PR checks (I manually checked):
- [x] LICENSE.APPROVED - already `Apache-2.0 WITH LLVM-exception`. Same file with `optional26/LICENSE`.
- [x] LICENSE.APACHE_LLVM - already `Apache-2.0 WITH LLVM-exception`. Same file with `optional26/LICENSE`.
- [x] LICENSE.CRITERIA - already `Apache-2.0 WITH LLVM-exception`. Same file with `optional26/LICENSE`.
- [x] TOPLEVEL.LICENSE  - already `Apache-2.0 WITH LLVM-exception`. Same file with `optional26/LICENSE`.
- [x] FILE.COPYRIGHT - already applied (no actual copyrights in code, except files copied from Boost - search for `Copyright (C) 2019 T. Zachary Laine` in `include/beman/iterator_interface/detail/stl_interfaces/` (3 files).

This PR updates/applies:
- [x] FILE.LICENSE_ID

PS. This PR will contains only added comments. NO actual issues in code / build system with be solved in this PR.