### PR TITLE
Update ci.yml and CMakePresets to enable gcc-{12, 13} and clang-19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,75 +1,42 @@
-name: Test
-
+name: CI Tests
 on:
+  workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
-
+    branches: [main]
 jobs:
   build:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
-
     strategy:
       fail-fast: false
-
       matrix:
         config:
-        - {
-          name: "Ubuntu Clang 17",
-          os: ubuntu-24.04,
-          toolchain: "clang-17-toolchain.cmake",
-          clang_version: 17,
-          installed_clang_version: 14,
-          cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "
-          }
-
-        - {
-          name: "Ubuntu Clang 18",
-          os: ubuntu-24.04,
-          toolchain: "clang-18-toolchain.cmake",
-          clang_version: 18,
-          installed_clang_version: 14,
-          cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "
-          }
-
-        - {
-            name: "Ubuntu GCC 13",
-            os: ubuntu-24.04,
-            toolchain: "gcc-13-toolchain.cmake",
-            clang_version: 17,
-            installed_clang_version: 14,
-            cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "
-          }
-
-        - {
-            name: "Ubuntu GCC 14",
-            os: ubuntu-24.04,
-            toolchain: "gcc-14-toolchain.cmake",
-            clang_version: 17,
-            installed_clang_version: 14,
-            cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "
-          }
+          # Note: clang-19 + Asan setup causes errors on some platforms. Temporary skip some checks via .asan_options.
+          - {name: "Ubuntu Clang 19", os: ubuntu-24.04, toolchain: "clang-19", clang_version: 19, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" ", asan_options: "new_delete_type_mismatch=0"}
+          - {name: "Ubuntu Clang 18", os: ubuntu-24.04, toolchain: "clang-18", clang_version: 18, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu Clang 17", os: ubuntu-24.04, toolchain: "clang-17", clang_version: 17, installed_clang_version: 17, cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu GCC 14", os: ubuntu-24.04, toolchain: "gcc-14", cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu GCC 13", os: ubuntu-24.04, toolchain: "gcc-13",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
+          - {name: "Ubuntu GCC 12", os: ubuntu-24.04, toolchain: "gcc-12",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
 
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-
       - uses: seanmiddleditch/gha-setup-ninja@master
-
       - name: Activate verbose shell
         run: set -x
-
       - name: Install LLVM+Clang
-        if: startsWith(matrix.config.os, 'ubuntu-')
+        if: startsWith(matrix.config.name, 'Ubuntu Clang')
         run: |
           set -x
           cat /etc/lsb-release
-          sudo apt-get remove clang-${{matrix.config.installed_clang_version}} \
-            lldb-${{matrix.config.installed_clang_version}} \
-            lld-${{matrix.config.installed_clang_version}} \
+          # Remove existing Clang installations.
+          sudo apt-get remove \
+            clang-${{matrix.config.installed_clang_version}} \
+            clang++-${{matrix.config.installed_clang_version}} \
             clangd-${{matrix.config.installed_clang_version}} \
             clang-tidy-${{matrix.config.installed_clang_version}} \
             clang-format-${{matrix.config.installed_clang_version}} \
@@ -78,40 +45,52 @@ jobs:
             lld-${{matrix.config.installed_clang_version}} \
             lldb-${{matrix.config.installed_clang_version}} \
             llvm-${{matrix.config.installed_clang_version}}-tools \
-            libomp-${{matrix.config.installed_clang_version}}-dev \
             libc++-${{matrix.config.installed_clang_version}}-dev \
             libc++abi-${{matrix.config.installed_clang_version}}-dev \
             libclang-common-${{matrix.config.installed_clang_version}}-dev \
             libclang-${{matrix.config.installed_clang_version}}-dev \
             libclang-cpp${{matrix.config.installed_clang_version}}-dev \
-            libunwind-${{matrix.config.installed_clang_version}}-dev
+            libomp-${{matrix.config.installed_clang_version}}-dev \
+            libunwind-${{matrix.config.installed_clang_version}}-dev \
+            libc++-dev libc++1 libc++abi-dev libc++abi1
+          # Install LLVM+Clang.
+          CLANG_VERSION=$(echo ${{matrix.config.toolchain}} | cut -d '-' -f2)
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh ${{matrix.config.clang_version}} all
-          sudo apt-get install libc++-dev libc++1 libc++abi-dev libc++abi1
-
-
-      - name: Install GCC 14
-        if: matrix.config.name == 'Ubuntu GCC 14'
+          sudo ./llvm.sh ${CLANG_VERSION} all
+          # Link Clang libraries (if not done by llvm.sh - some links are already set).
+          sudo ln -fs /usr/lib/llvm-${CLANG_VERSION}/lib/lib* /usr/lib/x86_64-linux-gnu/ || true
+          # If Clang 17, install a newer version of libc++ and libc++abi.
+          [[ ${CLANG_VERSION} = 17 ]] && sudo apt-get install libc++-dev libc++1 libc++abi-dev libc++abi1
+          find /usr/lib/x86_64-linux-gnu/ -name libc++.so* || true
+          clang++-${CLANG_VERSION} --version
+      - name: Install GCC
+        if: startsWith(matrix.config.name, 'Ubuntu GCC')
         run: |
+          set -x
+          # Remove existing GCC installations.
+          sudo apt-get remove gcc-13 g++-13 gcc-14 g++-14 gcc g++
           sudo apt update
-          sudo apt-get install g++-14
-
-
-      - name: Configure
+          # Install GCC.
+          GCC_VERSION=$(echo ${{matrix.config.toolchain}} | cut -d '-' -f2)
+          echo "GCC_VERSION=$GCC_VERSION"
+          sudo apt-get install g++-${GCC_VERSION} gcc-${GCC_VERSION}
+          find /usr/lib/x86_64-linux-gnu/ -name libstdc++.so*
+          g++-${GCC_VERSION} --version
+      - name: CMake Configure
         run: |
-          rm -rf .build
-          mkdir -p .build
-          cd .build
+          set -x
           echo ${{ matrix.config.cmake_args }}
           echo ${{ matrix.config.toolchain }}
-          cmake ${{ matrix.config.cmake_args }} -DCMAKE_TOOLCHAIN_FILE=etc/${{ matrix.config.toolchain }} -B . -S ..
-
-      - name: Build
+          rm -rf .build
+          cmake ${{ matrix.config.cmake_args }} -DCMAKE_TOOLCHAIN_FILE="etc/${{ matrix.config.toolchain }}-toolchain.cmake" -B .build -S .
+      - name: CMake Build
         run: |
+          set -x
           cmake --build .build --config Asan --target all -- -k 0
-
-      - name: Test
+      - name: CMake Test
         run: |
-          cd .build
-          ctest --output-on-failure
+          set -x
+          [[ ! -z "${{ matrix.config.asan_options }}" ]]  && export ASAN_OPTIONS="${{ matrix.config.asan_options }}"
+          ctest --build-config Asan --output-on-failure --test-dir .build
+

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,11 +32,39 @@
       "toolchainFile": "${sourceDir}/etc/gcc-14-toolchain.cmake"
     },
     {
+      "name": "gcc-13",
+      "inherits": "common",
+      "displayName": "GCC 13",
+      "description": "Build with GCC 13 compilers",
+      "toolchainFile": "${sourceDir}/etc/gcc-13-toolchain.cmake"
+    },
+    {
+      "name": "gcc-12",
+      "inherits": "common",
+      "displayName": "GCC 12",
+      "description": "Build with GCC 12 compilers",
+      "toolchainFile": "${sourceDir}/etc/gcc-12-toolchain.cmake"
+    },
+    {
+      "name": "clang-19",
+      "inherits": "common",
+      "displayName": "Clang 19",
+      "description": "Build with Clang 19 compilers",
+      "toolchainFile": "${sourceDir}/etc/clang-19-toolchain.cmake"
+    },
+    {
       "name": "clang-18",
       "inherits": "common",
       "displayName": "Clang 18",
       "description": "Build with Clang 18 compilers",
       "toolchainFile": "${sourceDir}/etc/clang-18-toolchain.cmake"
+    },
+    {
+      "name": "clang-17",
+      "inherits": "common",
+      "displayName": "Clang 17",
+      "description": "Build with Clang 17 compilers",
+      "toolchainFile": "${sourceDir}/etc/clang-17-toolchain.cmake"
     }
   ],
   "buildPresets": [
@@ -47,21 +75,45 @@
     },
     {
       "name": "system",
+      "inherits": "common",
       "configurePreset": "system"
     },
     {
       "name": "gcc-14",
+      "inherits": "common",
       "configurePreset": "gcc-14"
     },
     {
+      "name": "gcc-13",
+      "inherits": "common",
+      "configurePreset": "gcc-13"
+    },
+    {
+      "name": "gcc-12",
+      "inherits": "common",
+      "configurePreset": "gcc-12"
+    },
+    {
+      "name": "clang-19",
+      "inherits": "common",
+      "configurePreset": "clang-19"
+    },
+    {
       "name": "clang-18",
+      "inherits": "common",
       "configurePreset": "clang-18"
+    },
+    {
+      "name": "clang-17",
+      "inherits": "common",
+      "configurePreset": "clang-17"
     }
   ],
   "testPresets": [
     {
       "name": "common",
       "hidden": true,
+      "configuration": "Asan",
       "output": {
         "outputOnFailure": true
       },
@@ -81,9 +133,29 @@
       "configurePreset": "gcc-14"
     },
     {
+      "name": "gcc-13",
+      "inherits": "common",
+      "configurePreset": "gcc-13"
+    },
+    {
+      "name": "gcc-12",
+      "inherits": "common",
+      "configurePreset": "gcc-12"
+    },
+    {
+      "name": "clang-19",
+      "inherits": "common",
+      "configurePreset": "clang-19"
+    },
+    {
       "name": "clang-18",
       "inherits": "common",
       "configurePreset": "clang-18"
+    },
+    {
+      "name": "clang-17",
+      "inherits": "common",
+      "configurePreset": "clang-17"
     }
   ],
   "workflowPresets": [
@@ -122,6 +194,57 @@
       ]
     },
     {
+      "name": "gcc-13",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "gcc-13"
+        },
+        {
+          "type": "build",
+          "name": "gcc-13"
+        },
+        {
+          "type": "test",
+          "name": "gcc-13"
+        }
+      ]
+    },
+    {
+      "name": "gcc-12",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "gcc-12"
+        },
+        {
+          "type": "build",
+          "name": "gcc-12"
+        },
+        {
+          "type": "test",
+          "name": "gcc-12"
+        }
+      ]
+    },
+    {
+      "name": "clang-19",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "clang-19"
+        },
+        {
+          "type": "build",
+          "name": "clang-19"
+        },
+        {
+          "type": "test",
+          "name": "clang-19"
+        }
+      ]
+    },
+    {
       "name": "clang-18",
       "steps": [
         {
@@ -137,6 +260,24 @@
           "name": "clang-18"
         }
       ]
+    },
+    {
+      "name": "clang-17",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "clang-17"
+        },
+        {
+          "type": "build",
+          "name": "clang-17"
+        },
+        {
+          "type": "test",
+          "name": "clang-17"
+        }
+      ]
     }
   ]
 }
+


### PR DESCRIPTION
The PR imports the `ci.yml` and `CMakePresets` from [optional26 repository](https://github.com/beman-project/optional26):

- [x] Enable ASAN run with Clang-19 on CI

- [x] Enable gcc-14
- [x] Enable gcc-13
- [x] Enable gcc-12
- [x] Enable clang-19
- [x] Enable clang-18
- [x] Enable clang-17

Partially Fixes #18  and partially fixes #17
