### PR TITLE
tests: Apply beman standard to tests directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ add_subdirectory(include/beman/iterator_interface)
 
 add_subdirectory(examples)
 if(ITERATOR_INTERFACE_ENABLE_TESTING)
-  add_subdirectory(tests)
+  add_subdirectory(tests/beman/iterator_interface)
 endif()
 
 # Coverage

--- a/tests/beman/iterator_interface/CMakeLists.txt
+++ b/tests/beman/iterator_interface/CMakeLists.txt
@@ -1,5 +1,5 @@
 # cmake-format: off
-# tests/CMakeLists.txt -*-cmake-*-
+# tests/beman/iterator_interface/CMakeLists.txt -*-cmake-*-
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # cmake-format: on
 

--- a/tests/beman/iterator_interface/iterator_interface.test.cpp
+++ b/tests/beman/iterator_interface/iterator_interface.test.cpp
@@ -1,4 +1,4 @@
-// tests/iterator_interfaces.test.cpp -*-C++-*-
+// tests/beman/iterator_interface/iterator_interfaces.test.cpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <beman/iterator_interface/iterator_interface.hpp>


### PR DESCRIPTION
- [x] DIRECTORY.INTERFACE_HEADERS
- [x] DIRECTORY.IMPLEMENTATION_HEADERS
- [x] DIRECTORY.SOURCES
- [x]  DIRECTORY.TESTS
- [x]  DIRECTORY.DOCS
- [x]  DIRECTORY.PAPERS

I verified `DIRECTORY.INTERFACE_HEADERS`,  `DIRECTORY.IMPLEMENTATION_HEADERS` and `DIRECTORY.SOURCES` and the structure was already good when reading the [beman standard](https://github.com/beman-project/beman/blob/main/docs/BEMAN_STANDARD.md).

I did the changes to apply the beman standard for `DIRECTORY.TESTS`

`DIRECTORY.DOCS` and `DIRECTORY.PAPERS` are missing, but they are not required to be present, according to the same standard