### PR TITLE
Add MSVC-specific deducing-this check

### DIFF
--- a/cmake/CompilerFeatureTest.cmake
+++ b/cmake/CompilerFeatureTest.cmake
@@ -17,7 +17,7 @@ function(beman_iterator_check_deducing_this result_var)
 #else
   #if defined(_MSC_VER) && (_MSC_VER >= 1932)
   #elif defined(__clang__)
-    #if __has_extension(cxx_explicit_this_parameter))
+    #if __has_extension(cxx_explicit_this_parameter)
     #else
       #error No deducing this support
     #endif

--- a/cmake/CompilerFeatureTest.cmake
+++ b/cmake/CompilerFeatureTest.cmake
@@ -12,7 +12,8 @@ include(CheckCXXSourceCompiles)
 function(beman_iterator_check_deducing_this result_var)
   check_cxx_source_compiles( "
 // clang-specific check due to http://github.com/llvm/llvm-project/issues/113174
-#if defined(__cpp_explicit_this_parameter) || (defined(__clang__) && __has_extension(cxx_explicit_this_parameter))
+// MSVC-specific check due to https://developercommunity.visualstudio.com/t/10107077
+#if defined(__cpp_explicit_this_parameter) || (defined(__clang__) && __has_extension(cxx_explicit_this_parameter)) || (defined(_MSC_VER) && _MSC_VER >= 1932)
 #else
 #error No deducing this support
 #endif

--- a/cmake/CompilerFeatureTest.cmake
+++ b/cmake/CompilerFeatureTest.cmake
@@ -13,9 +13,17 @@ function(beman_iterator_check_deducing_this result_var)
   check_cxx_source_compiles( "
 // clang-specific check due to http://github.com/llvm/llvm-project/issues/113174
 // MSVC-specific check due to https://developercommunity.visualstudio.com/t/10107077
-#if defined(__cpp_explicit_this_parameter) || (defined(__clang__) && __has_extension(cxx_explicit_this_parameter)) || (defined(_MSC_VER) && _MSC_VER >= 1932)
+#if defined(__cpp_explicit_this_parameter)
 #else
-#error No deducing this support
+  #if defined(_MSC_VER) && (_MSC_VER >= 1932)
+  #elif defined(__clang__)
+    #if __has_extension(cxx_explicit_this_parameter))
+    #else
+      #error No deducing this support
+    #endif
+  #else
+    #error No deducing this support
+  #endif
 #endif
 int main(){}
 " HAVE_DEDUCING_THIS )


### PR DESCRIPTION
This compiler, like clang, doesn't properly advertise deducing this
support.

I really don't know the point of these feature test macros if we have to
work around them not being used for almost every compiler. :(
