### PR TITLE
Address iterator_category failing to compile for input iterators

### DIFF
--- a/include/beman/iterator_interface/iterator_interface.hpp
+++ b/include/beman/iterator_interface/iterator_interface.hpp
@@ -142,6 +142,7 @@ struct iter_cat<IteratorConcept, ReferenceType, false> {};
 
 template <typename IteratorConcept, typename ReferenceType>
 struct iter_cat<IteratorConcept, ReferenceType, true> {
+private:
     static constexpr auto compute_category_tag() {
         if constexpr (!std::is_reference_v<ReferenceType>) {
             return std::input_iterator_tag{};
@@ -154,19 +155,18 @@ struct iter_cat<IteratorConcept, ReferenceType, true> {
         }
     }
 
-    using TagType           = std::invoke_result_t<decltype(compute_category_tag)>;
-    using iterator_category = TagType;
+public:
+    using iterator_category = std::invoke_result_t<decltype(compute_category_tag)>;
 };
 
 } // namespace detail
 
 template <class IteratorConcept, class ValueType, class Reference, class Pointer, class DifferenceType>
-class iterator_interface {
+class iterator_interface
+    : detail::iter_cat<IteratorConcept, Reference, std::derived_from<IteratorConcept, std::forward_iterator_tag>>
+{
   public:
     using iterator_concept = IteratorConcept;
-    using iterator_category =
-        detail::iter_cat<IteratorConcept, Reference, std::derived_from<IteratorConcept, std::forward_iterator_tag>>::
-            iterator_category;
     using value_type      = remove_const_t<ValueType>;
     using reference       = Reference;
     using pointer         = conditional_t<is_same_v<iterator_concept, output_iterator_tag>, void, Pointer>;

--- a/tests/beman/iterator_interface/iterator_interface.test.cpp
+++ b/tests/beman/iterator_interface/iterator_interface.test.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <iterator>
 #include <ranges>
 
 namespace beman {
@@ -118,6 +119,35 @@ TEST(IteratorTest, OperatorArrow) {
     AlwaysIterator ai;
     ASSERT_EQ(ai->f(), 3);
 }
+
+struct dummy_input_iterator :
+    public ext_iterator_interface_compat<
+      dummy_input_iterator, std::input_iterator_tag, int, int const&, void, std::ptrdiff_t> {
+  constexpr dummy_input_iterator() { }
+  dummy_input_iterator(dummy_input_iterator const&) = delete;
+  dummy_input_iterator& operator=(dummy_input_iterator const&) = delete;
+  dummy_input_iterator(dummy_input_iterator&&) = default;
+  dummy_input_iterator& operator=(dummy_input_iterator&&) = default;
+  constexpr reference operator*() const {
+    return foo;
+  }
+  constexpr dummy_input_iterator& operator++() {
+    return *this;
+  }
+  constexpr void operator++(int) {}
+
+  friend constexpr bool operator==(std::default_sentinel_t const&,
+                                   dummy_input_iterator const&) {
+    return true;
+  }
+
+  friend beman::iterator_interface::iterator_interface_access;
+
+  int foo = 0;
+};
+
+static_assert(std::input_iterator<dummy_input_iterator>);
+static_assert(!std::forward_iterator<dummy_input_iterator>);
 
 } // namespace iterator_interface
 } // namespace beman


### PR DESCRIPTION
The wording of P2727R4 states, with respect to the iterator_category type alias:

"The nested type iterator_category is defined if and only if IteratorConcept is derived from forward_iterator_tag."

Previously, this implementation had attempted to implement this using a class template detail::iter_cat, which had a specialization that contained an iterator_category member type alias which was only enabled if IteratorConcept was derived from
std::forward_iterator_tag. However, the iter_category member type alias of iterator_interface itself was specified as detail::iter_cat</* ... */>>::iterator_category, which caused iterator_interface to simply fail to compile if IteratorConcept was not derived from forward_iterator_tag as detail::iter_cat's iterator_category was not found.

This commit addresses the issue by removing the iterator_category member type alias from iterator_interface itself and making iterator_interface provide the member type alias by inheriting from detail::iter_cat, which satisfies the requirement in the wording. It also adds a reproducing unit test.