### PR TITLE
Workaround for compilation failure on MSVC

### DIFF
--- a/include/beman/iterator_interface/iterator_interface.hpp
+++ b/include/beman/iterator_interface/iterator_interface.hpp
@@ -142,21 +142,17 @@ struct iter_cat<IteratorConcept, ReferenceType, false> {};
 
 template <typename IteratorConcept, typename ReferenceType>
 struct iter_cat<IteratorConcept, ReferenceType, true> {
-private:
-    static constexpr auto compute_category_tag() {
-        if constexpr (!std::is_reference_v<ReferenceType>) {
-            return std::input_iterator_tag{};
-        } else if constexpr (std::is_base_of_v<std::random_access_iterator_tag, IteratorConcept>) {
-            return std::random_access_iterator_tag{};
-        } else if constexpr (std::is_base_of_v<std::bidirectional_iterator_tag, IteratorConcept>) {
-            return std::bidirectional_iterator_tag{};
-        } else {
-            return std::forward_iterator_tag{};
-        }
-    }
-
-public:
-    using iterator_category = std::invoke_result_t<decltype(compute_category_tag)>;
+    using iterator_category =
+        std::conditional_t<
+            !std::is_reference_v<ReferenceType>,
+            std::input_iterator_tag,
+            std::conditional_t<
+                std::is_base_of_v<std::random_access_iterator_tag, IteratorConcept>,
+                std::random_access_iterator_tag,
+                std::conditional_t<
+                    std::is_base_of_v<std::bidirectional_iterator_tag, IteratorConcept>,
+                    std::bidirectional_iterator_tag,
+                    std::forward_iterator_tag>>>;
 };
 
 } // namespace detail


### PR DESCRIPTION
This commit depends on
https://github.com/beman-project/iterator_interface/pull/27.

There is implementation divergence as to whether the following code is
accepted:

```
template <typename T>
struct foo {
    static constexpr auto baz() {
        return 0;
    }
    using quux = decltype(baz);
};
```

It is accepted by GCC and Clang, and rejected by MSVC and sometimes
by EDG: https://godbolt.org/z/dW964rqec

Because the calculation of the iterator_category depended on code of
this form, previously, MSVC would fail to compile iterator_interface
with this error:

error C3539: a template-argument cannot be a type that contains 'auto'

In order to work around this issue, the static member function-based
metaprogramming has been replaced with the use of std::conditional_t.

After this change, MSVC successfully compiles and runs all the tests.