### PR TITLE
[NFC] Remove extra branch name in CI YAML file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main, ci]
+    branches: [main]
   pull_request:
     branches: [main]
 jobs:


### PR DESCRIPTION
Follow-up to #38.

I don't know why I didn't do it at the time, but I didn't remove the `ci` branch from the list of Git branches to run the CI on, and I forgot to do it after that PR got a +1. This PR fixes that oversight and ensures that the CI is only run on the `main` branch.