### PR TITLE
Add badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: 2.0 license with LLVM exceptions
 # beman.iterator_interface: iterator creation mechanisms
 
 <!-- markdownlint-disable -->
-<img src="https://github.com/bemanproject/beman/blob/main/images/logos/beman_logo-beman_library_under_development.png" style="width:5%; height:auto;"> ![CI Tests](https://github.com/bemanproject/iterator_interface/actions/workflows/ci.yml/badge.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) <img src="https://github.com/bemanproject/beman/blob/main/images/logos/beman_logo-beman_library_under_development.png" style="width:5%; height:auto;"> ![CI Tests](https://github.com/bemanproject/iterator_interface/actions/workflows/ci.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
 <!-- markdownlint-enable -->
 
 **Implements**: [`std::iterator_interface` (P2727R4)](https://wg21.link/P2727R4)


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/258

Add the library status and standard target badges in README.md to show the current status of the library and when will it be integrated in the c++ standard.