### PR TITLE
Fix first line linter error on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+# beman.iterator_interface: iterator creation mechanisms
+
 <!--
 SPDX-License-Identifier: 2.0 license with LLVM exceptions
 -->
-
-# beman.iterator_interface: iterator creation mechanisms
 
 <!-- markdownlint-disable -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) <img src="https://github.com/bemanproject/beman/blob/main/images/logos/beman_logo-beman_library_under_development.png" style="width:5%; height:auto;"> ![CI Tests](https://github.com/bemanproject/iterator_interface/actions/workflows/ci.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/258

Move the library title and short description at the top of the README.md file.