### PR TITLE
Remove copyright from config.hpp

### DIFF
--- a/include/beman/iterator_interface/detail/stl_interfaces/config.hpp
+++ b/include/beman/iterator_interface/detail/stl_interfaces/config.hpp
@@ -1,7 +1,6 @@
 // include/beman/iterator_interface/detail/stl_interfaces/config.hpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Copyright (C) 2020 T. Zachary Laine
 //
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/258

Remove the copyright line ```// Copyright (C) 2020 T. Zachary Laine``` from config.hpp