### PR TITLE
Remove copyright from iterator_interface.hpp

### DIFF
--- a/include/beman/iterator_interface/detail/stl_interfaces/iterator_interface.hpp
+++ b/include/beman/iterator_interface/detail/stl_interfaces/iterator_interface.hpp
@@ -1,7 +1,6 @@
 // include/beman/iterator_interface/detail/stl_interfaces/iterator_interface.hpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Copyright (C) 2019 T. Zachary Laine
 //
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/258

Remove the copyright message: ``` // Copyright (C) 2019 T. Zachary Laine ``` from iterator_interface.hpp.