### PR TITLE
Expose BEMAN_ITERATOR_INTERFACE_USE_DEDUCING_THIS as a vcpkg feature

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   beman-submodule-check:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.6.1
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-submodule-check.yml@1.7.0
 
   preset-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.6.1
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-preset-test.yml@1.7.0
     with:
       matrix_config: >
         [
@@ -27,7 +27,7 @@ jobs:
         ]
 
   build-and-test:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.6.1
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.7.0
     with:
       matrix_config: >
         {
@@ -119,12 +119,17 @@ jobs:
         }
 
   vcpkg-ci:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.6.1
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-ci.yml@1.7.0
     with:
       port_name: beman-iterator-interface
       container_image: ghcr.io/bemanproject/infra-containers-gcc:14
+      feature_combinations: |
+        [
+          {"features": {}},
+          {"features": {"use-deducing-this": false}}
+        ]
 
   create-issue-when-fault:
     needs: [preset-test, build-and-test]
     if: failure() && github.event_name == 'schedule'
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.6.1
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.7.0

--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -16,4 +16,4 @@ permissions:
 
 jobs:
   pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.6.1
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-pre-commit.yml@1.7.0

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   auto-update-pre-commit:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.6.1
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-update-pre-commit.yml@1.7.0
     secrets:
       APP_ID: ${{ secrets.AUTO_PR_BOT_APP_ID }}
       PRIVATE_KEY: ${{ secrets.AUTO_PR_BOT_PRIVATE_KEY }}

--- a/.github/workflows/vcpkg-release.yml
+++ b/.github/workflows/vcpkg-release.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 jobs:
   vcpkg-release:
-    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-release.yml@1.6.1
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-vcpkg-release.yml@1.7.0
     with:
       port_name: beman-iterator-interface
     secrets:

--- a/port/portfile.cmake.in
+++ b/port/portfile.cmake.in
@@ -6,9 +6,16 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        use-deducing-this   BEMAN_ITERATOR_INTERFACE_USE_DEDUCING_THIS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBEMAN_ITERATOR_INTERFACE_BUILD_TESTS=OFF
         -DBEMAN_ITERATOR_INTERFACE_BUILD_EXAMPLES=OFF
 )

--- a/port/vcpkg.json.in
+++ b/port/vcpkg.json.in
@@ -13,5 +13,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": ["use-deducing-this"],
+  "features": {
+    "use-deducing-this": {
+      "description": "Use deducing this for CRTP-free interface (BEMAN_ITERATOR_INTERFACE_USE_DEDUCING_THIS=ON)"
+    }
+  }
 }


### PR DESCRIPTION
Add a use-deducing-this feature to the port manifest (as a default feature) and translate it via vcpkg_check_features into the CMake option, so consumers can install
beman-iterator-interface[use-deducing-this] or disable it with beman-iterator-interface[core] to opt out.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
