### PR TITLE
fix(file.license_id): add/move SPDX identifiers and exclude stl_interfaces

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+ignored_paths:
+  - include/beman/iterator_interface/detail/stl_interfaces/

--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Lint Check (pre-commit)
 
 on:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md033.md
 # Disable inline html linter is needed for <details> <summary>
 MD033: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:

--- a/cmake/CompilerFeatureTest.cmake
+++ b/cmake/CompilerFeatureTest.cmake
@@ -1,6 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # cmake-format: off
 # cmake/CompilerFeatureTest.cmake -*-cmake-*-
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # cmake-format: on
 
 # Functions that determine compiler capabilities

--- a/examples/filter_int_iterator.cpp
+++ b/examples/filter_int_iterator.cpp
@@ -1,5 +1,5 @@
-// examples/filter_int_iterator.cpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// examples/filter_int_iterator.cpp -*-C++-*-
 
 // [P2727](https://wg21.link/P2727) example:
 // An iterator that allows filtering int elements of a sequence.

--- a/examples/repeated_chars_iterator.cpp
+++ b/examples/repeated_chars_iterator.cpp
@@ -1,5 +1,5 @@
-// examples/repeated_chars_iterator.cpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// examples/repeated_chars_iterator.cpp -*-C++-*-
 
 // [P2727](https://wg21.link/P2727) example:
 // An iterator that allows iterating over repetitions of a sequence of characters.

--- a/include/beman/iterator_interface/config.hpp
+++ b/include/beman/iterator_interface/config.hpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #ifndef BEMAN_ITERATOR_INTERFACE_CONFIG_HPP
 #define BEMAN_ITERATOR_INTERFACE_CONFIG_HPP
 

--- a/include/beman/iterator_interface/iterator_interface.hpp
+++ b/include/beman/iterator_interface/iterator_interface.hpp
@@ -1,5 +1,5 @@
-// include/beman/iterator_interface/iterator_interface.hpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// include/beman/iterator_interface/iterator_interface.hpp -*-C++-*-
 
 #ifndef INCLUDED_ITERATOR_INTERFACE
 #define INCLUDED_ITERATOR_INTERFACE

--- a/include/beman/iterator_interface/iterator_interface_access.hpp
+++ b/include/beman/iterator_interface/iterator_interface_access.hpp
@@ -1,5 +1,5 @@
-// include/beman/iterator_interface/iterator_interface_access.hpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// include/beman/iterator_interface/iterator_interface_access.hpp -*-C++-*-
 
 #ifndef ITERATOR_INTERFACE_ACCESSS_HPP
 #define ITERATOR_INTERFACE_ACCESSS_HPP

--- a/infra/.github/workflows/pre-commit.yml
+++ b/infra/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Lint Check (pre-commit)
 
 on:

--- a/infra/.pre-commit-config.yaml
+++ b/infra/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/infra/cmake/BuildTelemetry.cmake
+++ b/infra/cmake/BuildTelemetry.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 include_guard(GLOBAL)
 
 include(${CMAKE_CURRENT_LIST_DIR}/BuildTelemetryConfig.cmake)

--- a/infra/cmake/BuildTelemetryConfig.cmake
+++ b/infra/cmake/BuildTelemetryConfig.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 include_guard(GLOBAL)
 
 set(BUILD_TELEMETRY_DIR ${CMAKE_CURRENT_LIST_DIR})

--- a/infra/cmake/telemetry.sh
+++ b/infra/cmake/telemetry.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 set -o nounset
 set -o errexit

--- a/infra/cmake/use-fetch-content.cmake
+++ b/infra/cmake/use-fetch-content.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 cmake_minimum_required(VERSION 3.24)
 
 include(FetchContent)

--- a/tests/beman/iterator_interface/iterator_interface.test.cpp
+++ b/tests/beman/iterator_interface/iterator_interface.test.cpp
@@ -1,5 +1,5 @@
-// tests/beman/iterator_interface/iterator_interfaces.test.cpp -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// tests/beman/iterator_interface/iterator_interfaces.test.cpp -*-C++-*-
 
 #include <beman/iterator_interface/iterator_interface.hpp>
 #include <beman/iterator_interface/iterator_interface.hpp>


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/258

## Summary

- Adds `.beman-tidy.yaml` to exclude `include/beman/iterator_interface/detail/stl_interfaces/` from beman-tidy checks — this directory contains code imported from another library and its copyright notices must be preserved as-is
- Adds missing `SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception` to `.github/workflows/pre-commit-check.yml`, `.markdownlint.yaml`, `.pre-commit-config.yaml`, `include/beman/iterator_interface/config.hpp`, and all files under `infra/`
- Moves `SPDX-License-Identifier` to line 1 (from line 2 or 3) in `cmake/CompilerFeatureTest.cmake`, `examples/filter_int_iterator.cpp`, `examples/repeated_chars_iterator.cpp`, `include/beman/iterator_interface/iterator_interface.hpp`, `include/beman/iterator_interface/iterator_interface_access.hpp`, and `tests/beman/iterator_interface/iterator_interface.test.cpp`

Fixes `file.license_id` beman-tidy check as required by [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#filelicense_id).

